### PR TITLE
Arch Linux Installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ exec --no-startup-id /path/to/alternating_layouts.py
 ### Arch Linux
 Install [xorg-utils](https://www.archlinux.org/packages/extra/any/xorg-utils/) from the official repos and [python2-i3-git](https://aur.archlinux.org/packages/python2-i3-git) from the AUR.
 
-Then add `exec --no-startup-id python2 /path/to/alternating_layouts.py` to your `~/.i3/config`.
+Then add 
+```
+exec --no-startup-id python2 /path/to/alternating_layouts.py
+```
+to your `~/.i3/config`.
 
 
 Screenshot


### PR DESCRIPTION
Not much to say here. I added installation instructions for arch. I've tested these myself and they work. I also removed some redundant ``` characters.
