### PR TITLE
prevents splitting when on "tabbed" layout

### DIFF
--- a/alternating_layouts.py
+++ b/alternating_layouts.py
@@ -36,7 +36,7 @@ def set_layout():
     for win in current_win:
         parent = find_parent(win['id'])
 
-        if parent and "rect" in parent:
+        if parent and "rect" in parent and parent['layout'] != 'tabbed':
             height = parent['rect']['height']
             width = parent['rect']['width']
 


### PR DESCRIPTION
Splitting on a workspace with a "tabbed" layout gives a lot of subtrees... And makes it very difficult to go back to a tabbed layout.