### PR TITLE
Fixes infinite loop when exiting X

### DIFF
--- a/alternating_layouts.py
+++ b/alternating_layouts.py
@@ -89,11 +89,16 @@ def main():
     last_line = ""
     while True:
         line = process.stdout.readline()
+        if line == b'': #X is dead
+            break
         if line == last_line:
             continue
         if regex.match(line):
             set_layout()
         last_line = line
+
+    process.kill()
+    sys.exit()
 
 if __name__ == "__main__":
     main()

--- a/alternating_layouts.py
+++ b/alternating_layouts.py
@@ -39,7 +39,9 @@ def set_layout():
     for win in current_win:
         parent = find_parent(win['id'])
 
-        if parent and "rect" in parent and parent['layout'] != 'tabbed':
+        if (parent and "rect" in parent
+                   and parent['layout'] != 'tabbed'
+                   and parent['layout'] != 'stacked'):
             height = parent['rect']['height']
             width = parent['rect']['width']
 


### PR DESCRIPTION
Prior to this, the script will go into an infinite loop when exiting X (and stopping `xprop`). `stdout.readline()` returns an empty byte `b''` when the `stdout` stream  of `xprop` is stopped. Since X has been exited, the script should exit as well. This fix should do just that (and does for me), but please review, I have no experience with Python.
I also stopped it from splitting when in 'stacked' layout similar to [this](https://github.com/olemartinorg/i3-alternating-layout/commit/e74e09295fcd6934bf2914bf9f8c58d1b373cf09).

Thanks for the really useful script btw :)