### PR TITLE
Always use a fresh copy of the focused window

### DIFF
--- a/alternating_layouts.py
+++ b/alternating_layouts.py
@@ -29,7 +29,7 @@ def set_layout(i3, e):
         focused window to either vertical or
         horizontal, depending on its width/height
     """
-    win = e.container
+    win = i3.get_tree().find_focused()
     parent = find_parent(i3, win.id)
 
     if (parent and parent.layout != 'tabbed'


### PR DESCRIPTION
fixes (?) #30. On sway when deleting a window the next `window_focus` event contains the old dimensions of the newly focused window before it was resized.