### PR TITLE
Handle focused window movement

### DIFF
--- a/alternating_layouts.py
+++ b/alternating_layouts.py
@@ -54,8 +54,8 @@ def print_help():
 def main():
     """
     Main function - listen for window focus
-        changes and call set_layout when focus
-        changes
+        changes and window movements,
+        call set_layout when applicable
     """
     opt_list, _ = getopt.getopt(sys.argv[1:], 'hp:')
     pid_file = None
@@ -72,6 +72,7 @@ def main():
 
     i3 = Connection()
     i3.on(Event.WINDOW_FOCUS, set_layout)
+    i3.on(Event.WINDOW_MOVE, set_layout)
     i3.main()
 
 


### PR DESCRIPTION
Basically makes the script listen to window movement as well since moving the focused window in a way that changes the split direction between windows makes spawning another window do so with the wrong orientation. I also changed the relevant comment to reflect that.

I know one could also change focus to another window and back as a workaround, but I don't think that should be necessary.